### PR TITLE
Bump versions to rebuild to address CVE-2025-47907

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ The released images are hosted on the [`csi-components` ECR Public Registry](htt
 
 | Project | Latest Released Version | Image Pull URI |
 | ------------- | ------------- | ------------- |
-| [external-attacher](https://github.com/kubernetes-csi/external-attacher) | v4.9.0-eksbuild.3 | `public.ecr.aws/csi-components/csi-attacher:v4.9.0-eksbuild.3` |
-| [node-driver-registrar](https://github.com/kubernetes-csi/node-driver-registrar) | v2.14.0-eksbuild.4 | `public.ecr.aws/csi-components/csi-node-driver-registrar:v2.14.0-eksbuild.4` |
-| [external-provisioner](https://github.com/kubernetes-csi/external-provisioner) | v5.3.0-eksbuild.3 | `public.ecr.aws/csi-components/csi-provisioner:v5.3.0-eksbuild.3` |
-| [external-resizer](https://github.com/kubernetes-csi/external-resizer) | v1.14.0-eksbuild.3 | `public.ecr.aws/csi-components/csi-resizer:v1.14.0-eksbuild.3` |
-| [external-snapshotter](https://github.com/kubernetes-csi/external-snapshotter) | v8.3.0-eksbuild.1 | `public.ecr.aws/csi-components/csi-snapshotter:v8.3.0-eksbuild.1` |
-| [livenessprobe](https://github.com/kubernetes-csi/livenessprobe) | v2.16.0-eksbuild.4 | `public.ecr.aws/csi-components/livenessprobe:v2.16.0-eksbuild.4` |
-| [snapshot-controller](https://github.com/kubernetes-csi/external-snapshotter) | v8.3.0-eksbuild.1 | `public.ecr.aws/csi-components/snapshot-controller:v8.3.0-eksbuild.1` |
+| [external-attacher](https://github.com/kubernetes-csi/external-attacher) | v4.9.0-eksbuild.4 | `public.ecr.aws/csi-components/csi-attacher:v4.9.0-eksbuild.4` |
+| [node-driver-registrar](https://github.com/kubernetes-csi/node-driver-registrar) | v2.14.0-eksbuild.5 | `public.ecr.aws/csi-components/csi-node-driver-registrar:v2.14.0-eksbuild.5` |
+| [external-provisioner](https://github.com/kubernetes-csi/external-provisioner) | v5.3.0-eksbuild.4 | `public.ecr.aws/csi-components/csi-provisioner:v5.3.0-eksbuild.4` |
+| [external-resizer](https://github.com/kubernetes-csi/external-resizer) | v1.14.0-eksbuild.4 | `public.ecr.aws/csi-components/csi-resizer:v1.14.0-eksbuild.4` |
+| [external-snapshotter](https://github.com/kubernetes-csi/external-snapshotter) | v8.3.0-eksbuild.2 | `public.ecr.aws/csi-components/csi-snapshotter:v8.3.0-eksbuild.2` |
+| [livenessprobe](https://github.com/kubernetes-csi/livenessprobe) | v2.16.0-eksbuild.5 | `public.ecr.aws/csi-components/livenessprobe:v2.16.0-eksbuild.5` |
+| [snapshot-controller](https://github.com/kubernetes-csi/external-snapshotter) | v8.3.0-eksbuild.2 | `public.ecr.aws/csi-components/snapshot-controller:v8.3.0-eksbuild.2` |
 
 ## Building
 

--- a/hack/release-config.yaml
+++ b/hack/release-config.yaml
@@ -5,22 +5,22 @@
 
 csi-attacher:
   tag: 'v4.9.0'
-  eksbuild: '3'
+  eksbuild: '4'
 csi-node-driver-registrar:
   tag: 'v2.14.0'
-  eksbuild: '4'
+  eksbuild: '5'
 csi-provisioner:
   tag: 'v5.3.0'
-  eksbuild: '3'
+  eksbuild: '4'
 csi-resizer:
   tag: 'v1.14.0'
-  eksbuild: '3'
+  eksbuild: '4'
 csi-snapshotter:
   tag: 'v8.3.0'
-  eksbuild: '1'
+  eksbuild: '2'
 livenessprobe:
   tag: 'v2.16.0'
-  eksbuild: '4'
+  eksbuild: '5'
 snapshot-controller:
   tag: 'v8.3.0'
-  eksbuild: '1'
+  eksbuild: '2'


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Bumps container versions to cause rebuild to address `CVE-2025-47907`. We don't need any patches for this CVE as it's addressed in Golang itself, just need to rebuild to get a new image with latest Golang version.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
