### PR TITLE
Add PR Comment Action for External Contributors

### DIFF
--- a/.github/workflows/binaries.yaml
+++ b/.github/workflows/binaries.yaml
@@ -18,6 +18,8 @@ on:
     branches:
       - main
   pull_request:
+    branches:
+      - main
 
 permissions:
   contents: read

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -18,6 +18,8 @@ on:
     branches:
       - main
   pull_request:
+    branches:
+      - main
 
 permissions:
   contents: read
@@ -33,6 +35,8 @@ concurrency:
   
 jobs:
   build-images:
+    # Only local PRs have access to the secret to run E2E tests, skip otherwise
+    if: ${{ github.event.pull_request.head.repo.full_name == 'aws/csi-components' }}
     runs-on:
       - codebuild-csi-components-e2e-${{ github.run_id }}-${{ github.run_attempt }}
     steps:

--- a/.github/workflows/pr-comment.yaml
+++ b/.github/workflows/pr-comment.yaml
@@ -1,0 +1,75 @@
+# Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: External PR Check
+on:
+  pull_request_target:
+    branches:
+      - fix-external-prs
+
+permissions:
+  contents: read
+  pull-requests: write
+  
+jobs:
+  pr-comment:
+    # Only comment on PRs from forked repos
+    if: ${{ github.event.pull_request.head.repo.full_name != 'aws/csi-components-test' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const body = `## Summary
+            Hello and thank you for your contribution to the **CSI Components** repository!
+
+            This PR was created from a fork of the upstream [\`aws/csi-components\` repository](https://github.com/aws/csi-components) - thus, the E2E tests CI job will not run. This is because the job requires significant dangerous AWS permissions to create [Amazon EKS](https://aws.amazon.com/eks/) and [kOps](https://kops.sigs.k8s.io/) Kubernetes clusters.
+
+            ## Instructions for Third Party Contributors
+
+            Maintainers will review your PR as per normal GitHub procedure, and approve and/or suggest changes as necessary. After the changes are ready to merge, a maintainer will transfer the changes to a branch on the upstream repository and open a new PR using the new branch. This will allow the changes to run against the E2E changes before being merged.
+
+            You may find it useful to pre-emptively run the E2E tests yourself to avoid any issues in the merging process. Currently, the CI runs the following E2E tests:
+
+            - \`make e2e/test-e2e-external\`
+            - \`make e2e/test-e2e-external-arm64\` 
+            - \`make e2e/test-e2e-external-eks-windows\`
+            - \`make e2e/test-e2e-external-eks-bottlerocket\`
+
+            _Note: These tests require access to an AWS account, and will temporarily create testing resources in the account that cost money. If the tests crash or otherwise exit early, they may leave resources behind that require manual cleanup._
+
+            ## Instructions for Maintainers
+
+            **If you are a maintainer and submitted this PR, close it and open the PR using a branch pushed to the upstream [\`aws/csi-components\` repository](https://github.com/aws/csi-components).**
+
+            If this is a third party contributor's PR, follow this procedure:
+            1. Review the PR's changes as normal
+            _If applicable, run associated E2E tests locally_
+            2. When the PR is ready to merge, in a checked out version of the upstrem repository:
+            \`\`\`bash
+            gh pr checkout ${{ github.event.pull_request.number }}
+            git switch -c pr-${{ github.event.pull_request.number }}
+            git push
+            \`\`\`
+            3. Visit https://github.com/aws/csi-components/pull/new/pr-${{ github.event.pull_request.number }} and create the PR
+            _Reuse the title and description of this PR if they are applicable_
+            4. Do not close this PR - GitHub will automatically close it after that PR is merged`;
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            })


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Sets some GH actions to only run against the `main` branch. Also, publishes a comment on PRs made from forked repos with an explanation and procedure for such PRs.

You can see an example of such comment here: https://github.com/aws/csi-components/pull/7#issuecomment-3259314873

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
