### PR TITLE
Add missing patterns to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,11 +3,13 @@ updates:
   # GitHub Actions dependencies
   - package-ecosystem: "github-actions"
     directory: "/"
+    patterns: ["*"]
     multi-ecosystem-group: "all-dependencies"
 
   # Docker dependencies
   - package-ecosystem: "docker"
     directory: "/"
+    patterns: ["*"]
     multi-ecosystem-group: "all-dependencies"
 
 multi-ecosystem-groups:


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* For some weird reason, `patterns` is required when using a multi ecosystem group: https://github.com/aws/csi-components/runs/49724003011

The docs say you can just use `*` so I did that: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/configuring-multi-ecosystem-updates#2-assign-ecosystems-to-groups-with-patterns

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
