### PR TITLE
Don't run janitor job on forked repos

### DIFF
--- a/.github/workflows/janitor.yaml
+++ b/.github/workflows/janitor.yaml
@@ -22,6 +22,8 @@ permissions:
   
 jobs:
   janitor:
+    # Don't run on forked repos
+    if: ${{ github.repository == 'aws/csi-components-test' }}
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Don't run the janitor job on forks as we won't have permissions

Also fixes the broken missing newline in the file


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
