### PR TITLE
Fix Trivy Workflow

### DIFF
--- a/.github/workflows/trivy-published.yaml
+++ b/.github/workflows/trivy-published.yaml
@@ -20,6 +20,7 @@ on:
 permissions:
   contents: read
   security-events: write
+  id-token: write
   
 jobs:
   trivy-published:
@@ -28,12 +29,26 @@ jobs:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838
+        with:
+          aws-region: us-west-2
+          role-to-assume: arn:aws:iam::797935246662:role/github-actions-csi-components
+          role-session-name: GithubActionsTrivy
+
+      # ECR Public has a per-IP ratelist for unauthenticated users, which is often hit on
+      # GitHub actions due to jobs sharing IPs - this ensures we don't get rate limited
+      - name: Login to Amazon ECR Public
+        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076
+        with:
+          registry-type: public
+
       - name: Run Trivy (SARIF Output)
         env:
           REGISTRY: public.ecr.aws/csi-components
           OUTPUT_SARIF: 'true'
-
         run: make all-trivy
+
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@f443b600d91635bebf5b0d9ebc620189c0d6fba5
         with:

--- a/hack/trivy.sh
+++ b/hack/trivy.sh
@@ -24,6 +24,8 @@ EKSBUILD="$(yq ".${IMAGE}.eksbuild" "${BASE_DIR}/release-config.yaml")"
 docker pull -q "${REGISTRY}/${IMAGE}:${TAG}-eksbuild.${EKSBUILD}"
 if [ -n "${OUTPUT_SARIF:+x}" ]; then
   docker run --rm -v /var/run/docker.sock:/var/run/docker.sock:ro public.ecr.aws/aquasecurity/trivy:latest image -f sarif "${REGISTRY}/${IMAGE}:${TAG}-eksbuild.${EKSBUILD}" > "${BASE_DIR}/../output/${IMAGE}.sarif"
+  # Required by GitHub to upload multiple SARIF files: https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning#uploading-more-than-one-sarif-file-for-a-commit
+  yq -i ".runs[].automationDetails.id = \"trivy/${IMAGE}/$(date +%s)\"" "${BASE_DIR}/../output/${IMAGE}.sarif"
 else
   docker run --rm -v /var/run/docker.sock:/var/run/docker.sock:ro public.ecr.aws/aquasecurity/trivy:latest image -q "${REGISTRY}/${IMAGE}:${TAG}-eksbuild.${EKSBUILD}"
 fi


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Our Trivy workflow is failing on the hour for one of two reasons:
- Firstly, if often hits the unauthenticated ECR Public rate limit, because we basically share that with the entire world that is using GH Actions - we bypass that problem by logging in to get our own dedicated limit
- Secondly, when it doesn't hit that limit, it hits a poorly documented limitation in the SARIF upload action that GitHub added a few months ago: https://github.blog/changelog/2025-07-21-code-scanning-will-stop-combining-multiple-sarif-runs-uploaded-in-the-same-sarif-file/


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
