### PR TITLE
Remove test from repo name in pr-comment workflow

### DIFF
--- a/.github/workflows/pr-comment.yaml
+++ b/.github/workflows/pr-comment.yaml
@@ -25,7 +25,7 @@ permissions:
 jobs:
   pr-comment:
     # Only comment on PRs from forked repos
-    if: ${{ github.event.pull_request.head.repo.full_name != 'aws/csi-components-test' }}
+    if: ${{ github.event.pull_request.head.repo.full_name != 'aws/csi-components' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Removes accidental testing name left into `pr-comment.yaml`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
