### PR TITLE
Add ECR Public login to Trivy PR workflow

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -91,6 +91,15 @@ jobs:
       - name: Login to Amazon ECR
         uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076
 
+      # ECR Public has a per-IP ratelist for unauthenticated users, which is often hit on
+      # GitHub actions due to jobs sharing IPs - this ensures we don't get rate limited
+      - name: Login to Amazon ECR Public
+        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076
+        env:
+          AWS_REGION: us-east-1
+        with:
+          registry-type: public
+
       - name: Scan Images
         id: scan-images
         # https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#example-of-a-multiline-string

--- a/.github/workflows/janitor.yaml
+++ b/.github/workflows/janitor.yaml
@@ -23,7 +23,7 @@ permissions:
 jobs:
   janitor:
     # Don't run on forked repos
-    if: ${{ github.repository == 'aws/csi-components-test' }}
+    if: ${{ github.repository == 'aws/csi-components' }}
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go

--- a/.github/workflows/trivy-published.yaml
+++ b/.github/workflows/trivy-published.yaml
@@ -40,6 +40,8 @@ jobs:
       # GitHub actions due to jobs sharing IPs - this ensures we don't get rate limited
       - name: Login to Amazon ECR Public
         uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076
+        env:
+          AWS_REGION: us-east-1
         with:
           registry-type: public
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Similar to #14 but adds ECR Public login for the E2E workflow, which sometimes is failing due to pulling the Trivy image.

Also fixes ECR public region in both actions, and a typo in the janitor job.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
