### PR TITLE
Switch trivy-published workflow account

### DIFF
--- a/.github/workflows/trivy-published.yaml
+++ b/.github/workflows/trivy-published.yaml
@@ -33,7 +33,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838
         with:
           aws-region: us-west-2
-          role-to-assume: arn:aws:iam::797935246662:role/github-actions-csi-components
+          role-to-assume: arn:aws:iam::702945799511:role/github-actions-csi-components
           role-session-name: GithubActionsTrivy
 
       # ECR Public has a per-IP ratelist for unauthenticated users, which is often hit on


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Switch Trivy Published workflow to standard CI account instead of release account.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
