### PR TITLE
Fix CVEs and bump versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ The released images are hosted on the [`csi-components` ECR Public Registry](htt
 
 | Project | Latest Released Version | Image Pull URI |
 | ------------- | ------------- | ------------- |
-| [external-attacher](https://github.com/kubernetes-csi/external-attacher) | v4.11.0-eksbuild.3 | `public.ecr.aws/csi-components/csi-attacher:v4.11.0-eksbuild.3` |
-| [node-driver-registrar](https://github.com/kubernetes-csi/node-driver-registrar) | v2.16.0-eksbuild.3 | `public.ecr.aws/csi-components/csi-node-driver-registrar:v2.16.0-eksbuild.3` |
-| [external-provisioner](https://github.com/kubernetes-csi/external-provisioner) | v6.2.0-eksbuild.2 | `public.ecr.aws/csi-components/csi-provisioner:v6.2.0-eksbuild.2` |
-| [external-resizer](https://github.com/kubernetes-csi/external-resizer) | v2.1.0-eksbuild.3 | `public.ecr.aws/csi-components/csi-resizer:v2.1.0-eksbuild.3` |
-| [external-snapshotter](https://github.com/kubernetes-csi/external-snapshotter) | v8.5.0-eksbuild.3 | `public.ecr.aws/csi-components/csi-snapshotter:v8.5.0-eksbuild.3` |
-| [livenessprobe](https://github.com/kubernetes-csi/livenessprobe) | v2.18.0-eksbuild.3 | `public.ecr.aws/csi-components/livenessprobe:v2.18.0-eksbuild.3` |
-| [snapshot-controller](https://github.com/kubernetes-csi/external-snapshotter) | v8.5.0-eksbuild.3 | `public.ecr.aws/csi-components/snapshot-controller:v8.5.0-eksbuild.3` |
-| [volume-modifier-for-k8s](https://github.com/awslabs/volume-modifier-for-k8s) | v0.9.4-eksbuild.1 | `public.ecr.aws/ebs-csi-driver/volume-modifier-for-k8s:v0.9.4-eksbuild.1` |
+| [external-attacher](https://github.com/kubernetes-csi/external-attacher) | v4.11.0-eksbuild.4 | `public.ecr.aws/csi-components/csi-attacher:v4.11.0-eksbuild.4` |
+| [node-driver-registrar](https://github.com/kubernetes-csi/node-driver-registrar) | v2.16.0-eksbuild.4 | `public.ecr.aws/csi-components/csi-node-driver-registrar:v2.16.0-eksbuild.4` |
+| [external-provisioner](https://github.com/kubernetes-csi/external-provisioner) | v6.2.0-eksbuild.3 | `public.ecr.aws/csi-components/csi-provisioner:v6.2.0-eksbuild.3` |
+| [external-resizer](https://github.com/kubernetes-csi/external-resizer) | v2.1.0-eksbuild.4 | `public.ecr.aws/csi-components/csi-resizer:v2.1.0-eksbuild.4` |
+| [external-snapshotter](https://github.com/kubernetes-csi/external-snapshotter) | v8.5.0-eksbuild.4 | `public.ecr.aws/csi-components/csi-snapshotter:v8.5.0-eksbuild.4` |
+| [livenessprobe](https://github.com/kubernetes-csi/livenessprobe) | v2.18.0-eksbuild.4 | `public.ecr.aws/csi-components/livenessprobe:v2.18.0-eksbuild.4` |
+| [snapshot-controller](https://github.com/kubernetes-csi/external-snapshotter) | v8.5.0-eksbuild.4 | `public.ecr.aws/csi-components/snapshot-controller:v8.5.0-eksbuild.4` |
+| [volume-modifier-for-k8s](https://github.com/awslabs/volume-modifier-for-k8s) | v0.9.4-eksbuild.2 | `public.ecr.aws/ebs-csi-driver/volume-modifier-for-k8s:v0.9.4-eksbuild.2` |
 
 ## Building
 

--- a/hack/release-config.yaml
+++ b/hack/release-config.yaml
@@ -5,25 +5,25 @@
 
 csi-attacher:
   tag: 'v4.11.0'
-  eksbuild: '3'
+  eksbuild: '4'
 csi-node-driver-registrar:
   tag: 'v2.16.0'
-  eksbuild: '3'
+  eksbuild: '4'
 csi-provisioner:
   tag: 'v6.2.0'
-  eksbuild: '2'
+  eksbuild: '3'
 csi-resizer:
   tag: 'v2.1.0'
-  eksbuild: '3'
+  eksbuild: '4'
 csi-snapshotter:
   tag: 'v8.5.0'
-  eksbuild: '3'
+  eksbuild: '4'
 livenessprobe:
   tag: 'v2.18.0'
-  eksbuild: '3'
+  eksbuild: '4'
 snapshot-controller:
   tag: 'v8.5.0'
-  eksbuild: '3'
+  eksbuild: '4'
 volume-modifier-for-k8s:
   tag: 'v0.9.4'
-  eksbuild: '1'
+  eksbuild: '2'

--- a/patches/dependency-patches.yaml
+++ b/patches/dependency-patches.yaml
@@ -10,19 +10,22 @@
 
 csi-attacher:
   golang.org/x/crypto: v0.46.0
-  go.opentelemetry.io/otel/sdk: v1.42.0
+  go.opentelemetry.io/otel/sdk: v1.43.0
   google.golang.org/grpc: v1.79.3
 csi-node-driver-registrar:
   google.golang.org/grpc: v1.79.3
 csi-provisioner:
+  go.opentelemetry.io/otel/sdk: v1.43.0
   google.golang.org/grpc: v1.79.3
 csi-resizer:
-  go.opentelemetry.io/otel/sdk: v1.42.0
+  go.opentelemetry.io/otel/sdk: v1.43.0
   google.golang.org/grpc: v1.79.3
 csi-snapshotter:
+  go.opentelemetry.io/otel/sdk: v1.43.0
   google.golang.org/grpc: v1.79.3
 livenessprobe: 
   google.golang.org/grpc: v1.79.3
 snapshot-controller: 
+  go.opentelemetry.io/otel/sdk: v1.43.0
   google.golang.org/grpc: v1.79.3
 volume-modifier-for-k8s: {}


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Fix all CVEs (by bumping dependencies) and bump all versions for release
(The CVEs from the go standard lib were already addressed in #68 and just need to be released, but the otel CVE needs to be fixed manually)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
