### PR TITLE
Properly escape comment from Trivy output by routing it through env variable

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -112,12 +112,14 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          TRIVY_OUTPUT: ${{ steps.scan-images.outputs.TRIVY_OUTPUT }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const body = `## Trivy Output
             \`\`\`
-            ${{ steps.scan-images.outputs.TRIVY_OUTPUT }}
+            ${process.env.TRIVY_OUTPUT}
             \`\`\``;
 
             github.rest.issues.createComment({


### PR DESCRIPTION
*Description of changes:* Fixes case when trivy output contains a backtick or other special escape sequence by routing the output via an environment variable rather than directly interpolating it into the script.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
