### PR TITLE
Add missing EKS-D image to QEMU job; Add missing ECR logins

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -54,6 +54,13 @@ jobs:
       - name: Login to Amazon ECR
         uses: aws-actions/amazon-ecr-login@19d944daaa35f0fa1d3f7f8af1d3f2e5de25c5b7 # v2.1.4
 
+      - name: Login to Amazon ECR Public
+        uses: aws-actions/amazon-ecr-login@19d944daaa35f0fa1d3f7f8af1d3f2e5de25c5b7 # v2.1.4
+        env:
+          AWS_REGION: us-east-1
+        with:
+          registry-type: public
+
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
@@ -152,7 +159,14 @@ jobs:
           aws-region: us-west-2
           role-to-assume: arn:aws:iam::702945799511:role/github-actions-csi-components
           role-session-name: GithubActionsE2E
-          
+
+      - name: Login to Amazon ECR Public
+        uses: aws-actions/amazon-ecr-login@19d944daaa35f0fa1d3f7f8af1d3f2e5de25c5b7 # v2.1.4
+        env:
+          AWS_REGION: us-east-1
+        with:
+          registry-type: public
+
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,13 +43,23 @@ jobs:
       - name: Login to Amazon ECR
         uses: aws-actions/amazon-ecr-login@19d944daaa35f0fa1d3f7f8af1d3f2e5de25c5b7 # v2.1.4
 
+      - name: Login to Amazon ECR Public
+        uses: aws-actions/amazon-ecr-login@19d944daaa35f0fa1d3f7f8af1d3f2e5de25c5b7 # v2.1.4
+        env:
+          AWS_REGION: us-east-1
+        with:
+          registry-type: public
+
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.26'
 
+      # Use EKS-D mirror of image to avoid Docker Hub rate limits
       - name: Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+        with:
+          image: public.ecr.aws/eks-distro-build-tooling/binfmt-misc:qemu-v7.0.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
- We already use the EKS-D `binfmt-misc` image in 2/3 `setup-qemu` actions, add it to the third from `release.yaml`
- Add some missing ECR/ECR Public logins to avoid rate limits

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
