### PR TITLE
add golang.org/x/crypto to dep patch yaml for csi-resizer for CVE

### DIFF
--- a/patches/dependency-patches.yaml
+++ b/patches/dependency-patches.yaml
@@ -20,6 +20,7 @@ csi-provisioner:
   go.opentelemetry.io/otel/sdk: v1.44.0
   google.golang.org/grpc: v1.81.1
 csi-resizer:
+  golang.org/x/crypto: v0.52.0
   golang.org/x/net: v0.55.0
   go.opentelemetry.io/otel/sdk: v1.44.0
   google.golang.org/grpc: v1.81.1


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

add `golang.org/x/crypto: v0.52.0` to dependency-patches.yaml for csi-resizer to address the CVEs that are being marked for the image since upstream didn't bump the version

build manually and used make trivy to scan it

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
