### PR TITLE
Adding WS2025 Build Target For Images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,3 +49,9 @@ COPY --from=builder /app/bin/$ENTRYPOINT /$ENTRYPOINT.exe
 COPY --from=builder /app/licenses/ /licenses/
 USER ContainerAdministrator
 ENTRYPOINT ["/$ENTRYPOINT.exe"]
+
+FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-windows-base:ltsc2025@sha256:d352efedbc8ac1346e3747f9df14bae87d04c431b521656fcbd57859122640fc AS windows-ltsc2025
+COPY --from=builder /app/bin/$ENTRYPOINT /$ENTRYPOINT.exe
+COPY --from=builder /app/licenses/ /licenses/
+USER ContainerAdministrator
+ENTRYPOINT ["/$ENTRYPOINT.exe"]

--- a/hack/static-config.yaml
+++ b/hack/static-config.yaml
@@ -8,7 +8,7 @@ csi-attacher:
   e2e-parameter: sidecars.attacher.image
 csi-node-driver-registrar:
   repo: https://github.com/kubernetes-csi/node-driver-registrar
-  targets: [amd64-linux-al2023, arm64-linux-al2023, amd64-windows-ltsc2019, amd64-windows-ltsc2022]
+  targets: [amd64-linux-al2023, arm64-linux-al2023, amd64-windows-ltsc2019, amd64-windows-ltsc2022, amd64-windows-ltsc2025]
   e2e-parameter: sidecars.nodeDriverRegistrar.image
 csi-provisioner:
   repo: https://github.com/kubernetes-csi/external-provisioner
@@ -24,7 +24,7 @@ csi-snapshotter:
   e2e-parameter: sidecars.snapshotter.image
 livenessprobe:
   repo: https://github.com/kubernetes-csi/livenessprobe
-  targets: [amd64-linux-al2023, arm64-linux-al2023, amd64-windows-ltsc2019, amd64-windows-ltsc2022]
+  targets: [amd64-linux-al2023, arm64-linux-al2023, amd64-windows-ltsc2019, amd64-windows-ltsc2022, amd64-windows-ltsc2025]
   e2e-parameter: sidecars.livenessProbe.image
 snapshot-controller:
   repo: https://github.com/kubernetes-csi/external-snapshotter


### PR DESCRIPTION
*Description of changes:*

Adding WS2025 build target for images.

### Testing

Ran
```
> make build image/livenessprobe

> crane manifest (liveness probe image in my private ECR)

{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 898,
         "digest": "sha256:a5cf2548f9ab7bc27d8d7630b375f28467ce3afb9088dc4a71f275f890e09a68",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 898,
         "digest": "sha256:405ee727df5eb1d0cb1cb86d0b64afb8c41d232fe4d279de421645fea9fdb569",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1096,
         "digest": "sha256:514d98a9fb0654daaa57d99c9663b24a7c3175203ef0385e3da06caad155ce66",
         "platform": {
            "architecture": "amd64",
            "os": "windows",
            "os.version": "10.0.17763.8755"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1096,
         "digest": "sha256:1b821e3f84a0d32a0138125076907c68d78ab99afaf638a4930b4480b5361c6e",
         "platform": {
            "architecture": "amd64",
            "os": "windows",
            "os.version": "10.0.20348.5139"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1096,
         "digest": "sha256:657e9fa9a6041b6d248c57118be9600db913b3f50670626fcf1ffb86822a7bfd",
         "platform": {
            "architecture": "amd64",
            "os": "windows",
            "os.version": "10.0.26100.32860"
         }
      }
   ]
}

```

and

```

> make build image/csi-node-driver-registrar

> crane manifest (csi-node-driver-registrar image in my private ECR)

{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 898,
         "digest": "sha256:50c75d0b875bcef298243cef578c66d623180c1fc5b429ed6409232e76ea35cf",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 898,
         "digest": "sha256:7214d42a756ece1d2917024de2a9953fdca1c63182594b22786f0001cc3ecd87",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1096,
         "digest": "sha256:ab4cd5c7027ac9678749fb3350f7a0c4a7e4594ef16938740c06d0fbaf04aee2",
         "platform": {
            "architecture": "amd64",
            "os": "windows",
            "os.version": "10.0.17763.8755"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1096,
         "digest": "sha256:91279a1188ea5a08490304723bbc88329000fde8e2223a5a914b46ef9f4c509c",
         "platform": {
            "architecture": "amd64",
            "os": "windows",
            "os.version": "10.0.20348.5139"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1096,
         "digest": "sha256:a822c746e6ad2d69df568fc6ecfe76555e97038cd6737356caa47f76457288ce",
         "platform": {
            "architecture": "amd64",
            "os": "windows",
            "os.version": "10.0.26100.32860"
         }
      }
   ]
}
   
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
