### PR TITLE
Release v6.3.0 provisioner

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The released images are hosted on the [`csi-components` ECR Public Registry](htt
 | ------------- | ------------- | ------------- |
 | [external-attacher](https://github.com/kubernetes-csi/external-attacher) | v4.12.0-eksbuild.2 | `public.ecr.aws/csi-components/csi-attacher:v4.12.0-eksbuild.2` |
 | [node-driver-registrar](https://github.com/kubernetes-csi/node-driver-registrar) | v2.17.0-eksbuild.2 | `public.ecr.aws/csi-components/csi-node-driver-registrar:v2.17.0-eksbuild.2` |
-| [external-provisioner](https://github.com/kubernetes-csi/external-provisioner) | v6.2.0-eksbuild.7 | `public.ecr.aws/csi-components/csi-provisioner:v6.2.0-eksbuild.7` |
+| [external-provisioner](https://github.com/kubernetes-csi/external-provisioner) | v6.3.0-eksbuild.1 | `public.ecr.aws/csi-components/csi-provisioner:v6.3.0-eksbuild.1` |
 | [external-resizer](https://github.com/kubernetes-csi/external-resizer) | v2.2.0-eksbuild.2 | `public.ecr.aws/csi-components/csi-resizer:v2.2.0-eksbuild.2` |
 | [external-snapshotter](https://github.com/kubernetes-csi/external-snapshotter) | v8.6.0-eksbuild.2 | `public.ecr.aws/csi-components/csi-snapshotter:v8.6.0-eksbuild.2` |
 | [livenessprobe](https://github.com/kubernetes-csi/livenessprobe) | v2.19.0-eksbuild.2 | `public.ecr.aws/csi-components/livenessprobe:v2.19.0-eksbuild.2` |

--- a/hack/release-config.yaml
+++ b/hack/release-config.yaml
@@ -10,8 +10,8 @@ csi-node-driver-registrar:
   tag: 'v2.17.0'
   eksbuild: '2'
 csi-provisioner:
-  tag: 'v6.2.0'
-  eksbuild: '7'
+  tag: 'v6.3.0'
+  eksbuild: '1'
 csi-resizer:
   tag: 'v2.2.0'
   eksbuild: '2'

--- a/patches/dependency-patches.yaml
+++ b/patches/dependency-patches.yaml
@@ -15,11 +15,7 @@ csi-attacher:
 csi-node-driver-registrar:
   golang.org/x/net: v0.55.0
   go.opentelemetry.io/otel: v1.44.0
-csi-provisioner:
-  golang.org/x/crypto: v0.52.0
-  golang.org/x/net: v0.55.0
-  go.opentelemetry.io/otel/sdk: v1.44.0
-  google.golang.org/grpc: v1.81.1
+csi-provisioner: {}
 csi-resizer:
   golang.org/x/crypto: v0.52.0
   golang.org/x/net: v0.55.0
@@ -34,3 +30,4 @@ livenessprobe:
 snapshot-controller:
   golang.org/x/net: v0.55.0
   go.opentelemetry.io/otel/sdk: v1.44.0
+volume-modifier-for-k8s: {}


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
- Bump to `v6.3.0` of provisioner
- Drop dep patches already in upstream
- Re-add `volume-modifier-for-k8s` back to patches file so it's consistent

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
