### PR TITLE
Patch grpc and cel-go CVEs in all components

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ The released images are hosted on the [`csi-components` ECR Public Registry](htt
 
 | Project | Latest Released Version | Image Pull URI |
 | ------------- | ------------- | ------------- |
-| [external-attacher](https://github.com/kubernetes-csi/external-attacher) | v4.12.0-eksbuild.3 | `public.ecr.aws/csi-components/csi-attacher:v4.12.0-eksbuild.3` |
-| [node-driver-registrar](https://github.com/kubernetes-csi/node-driver-registrar) | v2.17.0-eksbuild.3 | `public.ecr.aws/csi-components/csi-node-driver-registrar:v2.17.0-eksbuild.3` |
-| [external-provisioner](https://github.com/kubernetes-csi/external-provisioner) | v6.3.0-eksbuild.2 | `public.ecr.aws/csi-components/csi-provisioner:v6.3.0-eksbuild.2` |
-| [external-resizer](https://github.com/kubernetes-csi/external-resizer) | v2.2.1-eksbuild.1 | `public.ecr.aws/csi-components/csi-resizer:v2.2.1-eksbuild.1` |
-| [external-snapshotter](https://github.com/kubernetes-csi/external-snapshotter) | v8.6.0-eksbuild.3 | `public.ecr.aws/csi-components/csi-snapshotter:v8.6.0-eksbuild.3` |
-| [livenessprobe](https://github.com/kubernetes-csi/livenessprobe) | v2.19.0-eksbuild.3 | `public.ecr.aws/csi-components/livenessprobe:v2.19.0-eksbuild.3` |
-| [snapshot-controller](https://github.com/kubernetes-csi/external-snapshotter) | v8.6.0-eksbuild.3 | `public.ecr.aws/csi-components/snapshot-controller:v8.6.0-eksbuild.3` |
-| [volume-modifier-for-k8s](https://github.com/awslabs/volume-modifier-for-k8s) | v0.9.5-eksbuild.3 | `public.ecr.aws/ebs-csi-driver/volume-modifier-for-k8s:v0.9.5-eksbuild.3` |
+| [external-attacher](https://github.com/kubernetes-csi/external-attacher) | v4.12.0-eksbuild.4 | `public.ecr.aws/csi-components/csi-attacher:v4.12.0-eksbuild.4` |
+| [node-driver-registrar](https://github.com/kubernetes-csi/node-driver-registrar) | v2.17.0-eksbuild.4 | `public.ecr.aws/csi-components/csi-node-driver-registrar:v2.17.0-eksbuild.4` |
+| [external-provisioner](https://github.com/kubernetes-csi/external-provisioner) | v6.3.0-eksbuild.3 | `public.ecr.aws/csi-components/csi-provisioner:v6.3.0-eksbuild.3` |
+| [external-resizer](https://github.com/kubernetes-csi/external-resizer) | v2.2.1-eksbuild.2 | `public.ecr.aws/csi-components/csi-resizer:v2.2.1-eksbuild.2` |
+| [external-snapshotter](https://github.com/kubernetes-csi/external-snapshotter) | v8.6.0-eksbuild.4 | `public.ecr.aws/csi-components/csi-snapshotter:v8.6.0-eksbuild.4` |
+| [livenessprobe](https://github.com/kubernetes-csi/livenessprobe) | v2.19.0-eksbuild.4 | `public.ecr.aws/csi-components/livenessprobe:v2.19.0-eksbuild.4` |
+| [snapshot-controller](https://github.com/kubernetes-csi/external-snapshotter) | v8.6.0-eksbuild.4 | `public.ecr.aws/csi-components/snapshot-controller:v8.6.0-eksbuild.4` |
+| [volume-modifier-for-k8s](https://github.com/awslabs/volume-modifier-for-k8s) | v0.9.5-eksbuild.4 | `public.ecr.aws/ebs-csi-driver/volume-modifier-for-k8s:v0.9.5-eksbuild.4` |
 
 ## Building
 

--- a/hack/release-config.yaml
+++ b/hack/release-config.yaml
@@ -5,25 +5,25 @@
 
 csi-attacher:
   tag: 'v4.12.0'
-  eksbuild: '3'
+  eksbuild: '4'
 csi-node-driver-registrar:
   tag: 'v2.17.0'
-  eksbuild: '3'
+  eksbuild: '4'
 csi-provisioner:
   tag: 'v6.3.0'
-  eksbuild: '2'
+  eksbuild: '3'
 csi-resizer:
   tag: 'v2.2.1'
-  eksbuild: '1'
+  eksbuild: '2'
 csi-snapshotter:
   tag: 'v8.6.0'
-  eksbuild: '3'
+  eksbuild: '4'
 livenessprobe:
   tag: 'v2.19.0'
-  eksbuild: '3'
+  eksbuild: '4'
 snapshot-controller:
   tag: 'v8.6.0'
-  eksbuild: '3'
+  eksbuild: '4'
 volume-modifier-for-k8s:
   tag: 'v0.9.5'
-  eksbuild: '3'
+  eksbuild: '4'

--- a/patches/dependency-patches.yaml
+++ b/patches/dependency-patches.yaml
@@ -12,27 +12,39 @@ csi-attacher:
   golang.org/x/crypto: v0.54.0
   golang.org/x/net: v0.57.0
   go.opentelemetry.io/otel/sdk: v1.44.0
+  github.com/google/cel-go: v0.29.0
+  google.golang.org/grpc: v1.82.1
 csi-node-driver-registrar:
   golang.org/x/net: v0.57.0
   go.opentelemetry.io/otel: v1.44.0
+  google.golang.org/grpc: v1.82.1
 csi-provisioner:
   golang.org/x/crypto: v0.54.0
   golang.org/x/net: v0.57.0
+  github.com/google/cel-go: v0.29.0
+  google.golang.org/grpc: v1.82.1
 csi-resizer:
   golang.org/x/crypto: v0.54.0
   golang.org/x/net: v0.57.0
   go.opentelemetry.io/otel/sdk: v1.44.0
-  google.golang.org/grpc: v1.81.1
+  github.com/google/cel-go: v0.29.0
+  google.golang.org/grpc: v1.82.1
 csi-snapshotter:
   golang.org/x/crypto: v0.54.0
   golang.org/x/net: v0.57.0
   go.opentelemetry.io/otel/sdk: v1.44.0
+  github.com/google/cel-go: v0.29.0
+  google.golang.org/grpc: v1.82.1
 livenessprobe:
   golang.org/x/net: v0.57.0
   go.opentelemetry.io/otel: v1.44.0
+  google.golang.org/grpc: v1.82.1
 snapshot-controller:
   golang.org/x/crypto: v0.54.0
   golang.org/x/net: v0.57.0
   go.opentelemetry.io/otel/sdk: v1.44.0
+  github.com/google/cel-go: v0.29.0
+  google.golang.org/grpc: v1.82.1
 volume-modifier-for-k8s:
   golang.org/x/net: v0.57.0
+  google.golang.org/grpc: v1.82.1


### PR DESCRIPTION
- Bump google.golang.org/grpc to v1.82.1 (GHSA-hrxh-6v49-42gf, HIGH)
- Bump github.com/google/cel-go to v0.29.0 (GHSA-gcjh-h69q-9w9g, MEDIUM)
- Bump eksbuild for all images

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
